### PR TITLE
Bug fix/69 user role

### DIFF
--- a/src/DAO/UserDAO.php
+++ b/src/DAO/UserDAO.php
@@ -13,7 +13,7 @@ class UserDAO extends DAO
         $user->setId($row['id']);
         $user->setPseudo($row['pseudo']);
         $user->setCreatedAt($row['createdAt']);
-        $user->setRole($row['name']);
+        $user->setRole($row['role_id']);
         $user->setEmail($row['email']);
         $user->setNumberOfComments($this->countComments($user->getPseudo()));
 
@@ -22,7 +22,8 @@ class UserDAO extends DAO
 
     public function getUsers()
     {
-        $sql = 'SELECT user.id, user.pseudo, user.createdAt, role.name, user.email FROM user INNER JOIN role ON user.role_id ORDER BY user.id DESC';
+        //$sql = 'SELECT user.id, user.pseudo, user.createdAt, role.id, user.email FROM user INNER JOIN role ON user.role_id ORDER BY user.id DESC';
+        $sql = 'SELECT id, pseudo, createdAt, role_id, email FROM user ORDER BY user.id DESC';
         $result = $this->createQuery($sql);
         $users = [];
         foreach ($result as $row)

--- a/src/DAO/UserDAO.php
+++ b/src/DAO/UserDAO.php
@@ -74,9 +74,16 @@ class UserDAO extends DAO
         }
     }
 
-    public function checkPassword(Parameter $post)
+    public function checkPassword(Parameter $post, $field)
     {
-        $sql = 'SELECT user.id, user.pseudo, user.password, user.role_id AS roleId, role.name AS roleName, user.email FROM user INNER JOIN role ON role.id = user.role_id WHERE pseudo = ?';
+        if($field === 'pseudo')
+        {
+            $sql = 'SELECT user.id, user.pseudo, user.password, user.role_id AS roleId, role.name AS roleName, user.email, user.createdAt FROM user INNER JOIN role ON role.id = user.role_id WHERE pseudo = ?';
+        }
+        elseif($field === 'email')
+        {
+            $sql = 'SELECT user.id, user.pseudo, user.password, user.role_id AS roleId, role.name AS roleName, user.email, user.createdAt FROM user INNER JOIN role ON role.id = user.role_id WHERE email = ?';
+        }
         $data = $this->createQuery($sql, [$post->get('username')]);
         $result = $data->fetch();
         $isPasswordValid = password_verify($post->get('password'), $result['password']);

--- a/src/constraint/UserValidation.php
+++ b/src/constraint/UserValidation.php
@@ -79,9 +79,9 @@ class UserValidation extends Validation
         {
             return $this->constraint->minLength('password', $value, 6);
         }
-        if($this->constraint->maxLength($name, $value, 255))
+        if($this->constraint->maxLength($name, $value, 20))
         {
-            return $this->constraint->maxLength('password', $value, 255);
+            return $this->constraint->maxLength('password', $value, 20);
         }
     }
     private function checkEmail($value)

--- a/src/controller/BackController.php
+++ b/src/controller/BackController.php
@@ -40,7 +40,7 @@ class BackController extends Controller
             $articles = $this->articleDAO->getArticles(false);
             $comments = $this->commentDAO->getFlaggedComments();
             $users = $this->userDAO->getUsers();
-            var_dump($users);
+
             return $this->view->render('administration', [
                 'articles' => $articles,
                 'comments' => $comments,

--- a/src/controller/BackController.php
+++ b/src/controller/BackController.php
@@ -234,13 +234,19 @@ class BackController extends Controller
     {
         if($this->checkLoggedIn())
         {
-            if($post->get('submitPassword'))
+            if($post->get('submit'))
             {
-                $this->userDAO->updatePassword($post, $this->session->get('user')->getPseudo());
-                $this->session->set('update_password_message', 'Votre mot de passe a été mis à jour');
-                header('Location: ../public/index.php?route=profile');
+                $errors = $this->validation->validate($post, 'User');
+                if(!$errors) {
+                    $this->userDAO->updatePassword($post, $this->session->get('user')->getPseudo());
+                    $this->session->set('update_password_message', 'Votre mot de passe a été mis à jour');
+                    header('Location: ../public/index.php?route=profile');
+                }
+                return $this->view->render('update_password', [
+                    'errors' => $errors
+                ]);
             }
-            //return $this->view->render('update_password');
+            return $this->view->render('update_password');
         }
     }
 

--- a/src/controller/BackController.php
+++ b/src/controller/BackController.php
@@ -40,7 +40,7 @@ class BackController extends Controller
             $articles = $this->articleDAO->getArticles(false);
             $comments = $this->commentDAO->getFlaggedComments();
             $users = $this->userDAO->getUsers();
-
+            var_dump($users);
             return $this->view->render('administration', [
                 'articles' => $articles,
                 'comments' => $comments,

--- a/src/controller/BackController.php
+++ b/src/controller/BackController.php
@@ -8,9 +8,9 @@ class BackController extends Controller
 {
     private function checkLoggedIn()
     {
-        if(!$this->session->get('pseudo'))
+        if(!$this->session->get('user')->getPseudo())
         {
-            $this->session->set('need_login', 'Vous devez vous connecter pour accéder à cette page');
+            $this->session->set('need_login_message', 'Vous devez vous connecter pour accéder à cette page');
             header('Location: ../public/index.php?route=login');
         }
         else
@@ -22,9 +22,10 @@ class BackController extends Controller
     private function checkAdmin()
     {
         $this->checkLoggedIn();
-        if(!($this->session->get('role') === 'admin'))
+        //if(!($this->session->get('role') === 'admin'))
+        if(!($this->session->get('user')->getIsAdmin()))
         {
-            $this->session->set('not_admin', 'Vous ne disposez pas des autorisations suffisantes pour accéder à cette page');
+            $this->session->set('not_admin_message', 'Vous ne disposez pas des autorisations suffisantes pour accéder à cette page');
             header('Location: ../public/index.php?route=errorPermission');
         }
         else
@@ -80,8 +81,8 @@ class BackController extends Controller
                 $errors = $this->validation->validate($post, 'Article');
                 if(!$errors)
                 {
-                    $this->articleDAO->addArticle($post, $this->session->get('id'));
-                    $this->session->set('add_article', 'Le nouvel article a bien été ajouté');
+                    $this->articleDAO->addArticle($post, $this->session->get('user')->getId());
+                    $this->session->set('add_article_message', 'Le nouvel article a bien été ajouté');
                     header('Location: ../public/index.php?route=administration');
                 }
                 return $this->view->render('add_article', [
@@ -103,8 +104,8 @@ class BackController extends Controller
                 $errors = $this->validation->validate($post, 'Article');
                 if(!$errors)
                 {
-                    $this->articleDAO->editArticle($post, $articleId, $this->session->get('id'));
-                    $this->session->set('edit_article', 'L\'article a bien été modifié');
+                    $this->articleDAO->editArticle($post, $articleId, $this->session->get('user')->getId());
+                    $this->session->set('edit_article_message', 'L\'article a bien été modifié');
                 }
                 $post->set('id', $article->getId());
                 return $this->view->render('edit_article', [
@@ -117,8 +118,8 @@ class BackController extends Controller
                 $errors = $this->validation->validate($post, 'Article');
                 if(!$errors)
                 {
-                    $this->articleDAO->editArticle($post, $articleId, $this->session->get('id'));
-                    $this->session->set('edit_article', 'L\'article a bien été modifié');
+                    $this->articleDAO->editArticle($post, $articleId, $this->session->get('user')->getId());
+                    $this->session->set('edit_article_message', 'L\'article a bien été modifié');
                     header('Location: ../public/index.php?route=administration');
                 }
                 return $this->view->render('edit_article', [
@@ -144,7 +145,7 @@ class BackController extends Controller
     {
         if ($this->checkAdmin()) {
             $this->articleDAO->editPublicationStatus(1, $articleId);
-            $this->session->set('publish_article', 'Le chapitre a bien été publié');
+            $this->session->set('publish_article_message', 'Le chapitre a bien été publié');
             header('Location: ../public/index.php?route=administration');
         }
     }
@@ -153,7 +154,7 @@ class BackController extends Controller
     {
         if ($this->checkAdmin()) {
             $this->articleDAO->editPublicationStatus(0, $articleId);
-            $this->session->set('unpublish_article', 'Le chapitre a bien été dépublié');
+            $this->session->set('unpublish_article_message', 'Le chapitre a bien été dépublié');
             header('Location: ../public/index.php?route=administration');
         }
     }
@@ -163,7 +164,7 @@ class BackController extends Controller
         if($this->checkAdmin())
         {
             $this->articleDAO->deleteArticle($articleId);
-            $this->session->set('delete_article', 'L\'article a bien été supprimé');
+            $this->session->set('delete_article_message', 'L\'article a bien été supprimé');
             header('Location: ../public/index.php?route=administration');
         }
     }
@@ -177,8 +178,8 @@ class BackController extends Controller
                 $errors = $this->validation->validate($post, 'Comment');
                 if(!$errors)
                 {
-                    $this->commentDAO->addComment($post, $this->session->get('pseudo'), $articleId);
-                    $this->session->set('add_comment', 'Votre nouveau commentaire a bien été ajouté');
+                    $this->commentDAO->addComment($post, $this->session->get('user')->getPseudo(), $articleId);
+                    $this->session->set('add_comment_message', 'Votre nouveau commentaire a bien été ajouté');
                 }
                 $article = $this->articleDAO->getArticle($articleId, true);
                 $comments = $this->commentDAO->getCommentsFromArticle($articleId);
@@ -197,23 +198,23 @@ class BackController extends Controller
         if($this->checkAdmin())
         {
             $this->commentDAO->unflagComment($commentId);
-            $this->session->set('unflag_comment', 'Le commentaire a bien été désignalé');
+            $this->session->set('unflag_comment_message', 'Le commentaire a bien été désignalé');
             header('Location: ../public/index.php?route=administration');
         }
     }
 
     public function deleteComment($commentId, $articleId, $pseudo)
     {
-        if($this->checkLoggedIn() && $this->session->get('pseudo') === $pseudo)
+        if($this->checkLoggedIn() && $this->session->get('user')->getPseudo() === $pseudo)
         {
             $this->commentDAO->deleteComment($commentId);
-            $this->session->set('delete_comment', 'Votre commentaire a bien été supprimé');
+            $this->session->set('delete_comment_message', 'Votre commentaire a bien été supprimé');
             header('Location: ../public/index.php?route=viewArticle&articleId='.$articleId);
         }
         elseif($this->checkAdmin())
         {
             $this->commentDAO->deleteComment($commentId);
-            $this->session->set('delete_comment', 'Le commentaire a bien été supprimé');
+            $this->session->set('delete_comment_message', 'Le commentaire a bien été supprimé');
             header('Location: ../public/index.php?route=administration');
         }
     }
@@ -222,7 +223,7 @@ class BackController extends Controller
     {
         if($this->checkLoggedIn())
         {
-            $user = $this->userDAO->getUser($this->session->get('pseudo'));
+            $user = $this->userDAO->getUser($this->session->get('user')->getPseudo());
             return $this->view->render('profile', [
                 'user' => $user
             ]);
@@ -235,8 +236,8 @@ class BackController extends Controller
         {
             if($post->get('submitPassword'))
             {
-                $this->userDAO->updatePassword($post, $this->session->get('pseudo'));
-                $this->session->set('update_password', 'Votre mot de passe a été mis à jour');
+                $this->userDAO->updatePassword($post, $this->session->get('user')->getPseudo());
+                $this->session->set('update_password_message', 'Votre mot de passe a été mis à jour');
                 header('Location: ../public/index.php?route=profile');
             }
             //return $this->view->render('update_password');
@@ -249,8 +250,8 @@ class BackController extends Controller
         {
             if($post->get('submitEmail'))
             {
-                $this->userDAO->updateEmail($post, $this->session->get('pseudo'));
-                $this->session->set('update_email', 'Votre adresse e-mail a été mise à jour');
+                $this->userDAO->updateEmail($post, $this->session->get('user')->getPseudo());
+                $this->session->set('update_email_message', 'Votre adresse e-mail a été mise à jour');
                 header('Location: ../public/index.php?route=profile');
             }
             //return $this->view->render('profile');
@@ -269,7 +270,7 @@ class BackController extends Controller
     {
         if($this->checkLoggedIn())
         {
-            $this->userDAO->deleteAccount($this->session->get('pseudo'));
+            $this->userDAO->deleteAccount($this->session->get('user')->getPseudo());
             $this->logoutOrDelete('delete_account');
         }
     }
@@ -279,7 +280,7 @@ class BackController extends Controller
         if($this->checkAdmin())
         {
             $this->userDAO->deleteUser($userId);
-            $this->session->set('delete_user', 'L\'utilisateur a bien été supprimé');
+            $this->session->set('delete_user_message', 'L\'utilisateur a bien été supprimé');
             header('Location: ../public/index.php?route=administration');
         }
     }
@@ -290,11 +291,11 @@ class BackController extends Controller
         $this->session->start();
         if($param === 'logout')
         {
-            $this->session->set('logout', 'À bientôt');
+            $this->session->set('logout_message', 'À bientôt');
         }
         else
         {
-            $this->session->set('delete_account', 'Votre compte a bien été supprimé');
+            $this->session->set('delete_account_message', 'Votre compte a bien été supprimé');
         }
         header('Location: ../public/index.php');
     }

--- a/src/controller/FrontController.php
+++ b/src/controller/FrontController.php
@@ -75,13 +75,17 @@ class FrontController extends Controller
             if(!$checkUser)
             {
                 $checkUser = $this->userDAO->checkUser($post, 'username', 'email', 'login');
+                $checkPassword = $checkUser ? $this->userDAO->checkPassword($post, 'email'): '';
             }
-            $checkPassword = $checkUser ? $this->userDAO->checkPassword($post): '';
+            else
+            {
+                $checkPassword = $checkUser ? $this->userDAO->checkPassword($post, 'pseudo'): '';
+            }
 
             if ($checkPassword) {
-                $this->session->set('login_message', 'Content de vous revoir');
-                $this->session->set('user', $checkPassword['user']);
                 $this->session->set('loggedIn', true);
+                $this->session->set('user', $checkPassword['user']);
+                $this->session->set('login_message', 'Content de vous revoir '.$this->session->get('user')->getPseudo(). ' !');
                 header('Location: ../public/index.php');
             }
             else

--- a/src/controller/FrontController.php
+++ b/src/controller/FrontController.php
@@ -33,7 +33,7 @@ class FrontController extends Controller
     public function flagComment($commentId, $articleId)
     {
         $this->commentDAO->flagComment($commentId);
-        $this->session->set('flag_comment', 'Le commentaire a bien été signalé');
+        $this->session->set('flag_comment_message', 'Le commentaire a bien été signalé');
         header('Location: ../public/index.php?route=viewArticle&articleId='.$articleId);
     }
 
@@ -54,7 +54,7 @@ class FrontController extends Controller
             {
                 $this->userDAO->register($post);
                 $this->login($post);
-                $this->session->set('register', 'Votre inscription a bien été effectuée');
+                $this->session->set('register_message', 'Votre inscription a bien été effectuée');
                 header('Location: ../public/index.php');
             }
 
@@ -73,16 +73,14 @@ class FrontController extends Controller
             $result = $this->userDAO->login($post);
             if($result && $result['isPasswordValid'])
             {
-                $this->session->set('login', 'Content de vous revoir');
-                $this->session->set('id', $result['result']['id']);
-                $this->session->set('role', $result['result']['name']);
-                $this->session->set('pseudo', $post->get('pseudo'));
+                $this->session->set('login_message', 'Content de vous revoir');
+                $this->session->set('user', $result['user']);
                 $this->session->set('loggedIn', true);
                 header('Location: ../public/index.php');
             }
             else
             {
-                $this->session->set('error_login', 'Le pseudo et/ou le mot de passe sont incorrects');
+                $this->session->set('error_login_message', 'Le pseudo et/ou le mot de passe sont incorrects');
                 return $this->view->render('login', [
                     'post' => $post
                 ]);

--- a/src/model/User.php
+++ b/src/model/User.php
@@ -138,7 +138,7 @@ class User
      */
     public function setIsAdmin($isAdmin)
     {
-        if($this->getRole() === '1')
+        if($isAdmin === '1')
         {
             $this->isAdmin = true;
         }

--- a/src/model/User.php
+++ b/src/model/User.php
@@ -11,6 +11,7 @@ class User
     private $role;
     private $email;
     private $numberOfComments;
+    private $isAdmin;
 
     /**
      * @return int
@@ -123,4 +124,28 @@ class User
     {
         $this->numberOfComments = $numberOfComments;
     }
+
+    /**
+     * @return boolean
+     */
+    public function getIsAdmin()
+    {
+        return $this->isAdmin;
+    }
+
+    /**
+     * @param boolean $isAdmin
+     */
+    public function setIsAdmin($isAdmin)
+    {
+        if($this->getRole() === '1')
+        {
+            $this->isAdmin = true;
+        }
+        else
+        {
+            $this->isAdmin = false;
+        }
+    }
+
 }

--- a/templates/administration.php
+++ b/templates/administration.php
@@ -170,7 +170,7 @@
             </td>
             <td>
                 <?php
-                if($user->getRole() !== '1')
+                if(!$user->getIsAdmin())
                 {
                     ?>
                     <a href="../public/index.php?route=deleteUser&userId=<?= $user->getId(); ?>">

--- a/templates/administration.php
+++ b/templates/administration.php
@@ -1,13 +1,13 @@
 <?php $this->title = 'Administration'; ?>
 
-<?= $this->session->show('add_article'); ?>
-<?= $this->session->show('edit_article'); ?>
-<?= $this->session->show('delete_article'); ?>
-<?= $this->session->show('publish_article'); ?>
-<?= $this->session->show('unpublish_article'); ?>
-<?= $this->session->show('unflag_comment'); ?>
-<?= $this->session->show('delete_comment'); ?>
-<?= $this->session->show('delete_user'); ?>
+<?= $this->session->show('add_article_message'); ?>
+<?= $this->session->show('edit_article_message'); ?>
+<?= $this->session->show('delete_article_message'); ?>
+<?= $this->session->show('publish_article_message'); ?>
+<?= $this->session->show('unpublish_article_message'); ?>
+<?= $this->session->show('unflag_comment_message'); ?>
+<?= $this->session->show('delete_comment_message'); ?>
+<?= $this->session->show('delete_user_message'); ?>
 
 <h2>Articles</h2>
 <a href="../public/index.php?route=addArticle">Nouvel article</a>

--- a/templates/administration.php
+++ b/templates/administration.php
@@ -170,7 +170,7 @@
             </td>
             <td>
                 <?php
-                if($user->getRole() != 'admin')
+                if($user->getRole() !== '1')
                 {
                     ?>
                     <a href="../public/index.php?route=deleteUser&userId=<?= $user->getId(); ?>">

--- a/templates/base.php
+++ b/templates/base.php
@@ -13,9 +13,9 @@
         <header>
             <a href="../public/index.php">Accueil</a>
             <?php
-            if($this->session->get('pseudo'))
+            if($this->session->get('loggedIn'))
             {
-                if($this->session->get('role') === 'admin') {
+                if(!$this->session->get('not_admin')) {
                 ?>
                 <a href="../public/index.php?route=administration">Administration</a>
                 <?php

--- a/templates/edit_article.php
+++ b/templates/edit_article.php
@@ -1,7 +1,7 @@
 <?php $this->title = 'Modifier l\'article'; ?>
 <?php $this->script =  'src="https://cdn.tiny.cloud/1/8tzv2jc2jx5cy4ulyl2dvykrlorgyrfsyawguzw4kzmtly5t/tinymce/5/tinymce.min.js" referrerpolicy="origin"'; ?>
 
-<?= $this->session->show('edit_article'); ?>
+<?= $this->session->show('edit_article_message'); ?>
 
 <a href="../public/index.php?route=administration"><< Retour à l'administration</a>
 

--- a/templates/error_permission.php
+++ b/templates/error_permission.php
@@ -1,7 +1,7 @@
 <?php $this->title = "Privilèges insuffisants"; ?>
 
 <p>
-    <?= $this->session->show('not_admin'); ?>
+    <?= $this->session->show('not_admin_message'); ?>
 </p>
 
 <a href="../public/index.php"><< Retour à l'accueil</a>

--- a/templates/home.php
+++ b/templates/home.php
@@ -1,10 +1,10 @@
 <?php $this->title = "Accueil"; ?>
 
-<?= $this->session->show('register'); ?>
-<?= $this->session->show('login'); ?>
-<?= $this->session->show('logout'); ?>
-<?= $this->session->show('delete_user'); ?>
-<?= $this->session->show('delete_account'); ?>
+<?= $this->session->show('register_message'); ?>
+<?= $this->session->show('login_message'); ?>
+<?= $this->session->show('logout_message'); ?>
+<?= $this->session->show('delete_user_message'); ?>
+<?= $this->session->show('delete_account_message'); ?>
 
 <?php
 foreach ($articles as $article)

--- a/templates/login.php
+++ b/templates/login.php
@@ -5,9 +5,9 @@
 
 <div>
     <form method="post" action="../public/index.php?route=login">
-        <label for="pseudo">Pseudo</label>
+        <label for="pseudo">Pseudo ou e-mail</label>
         <br />
-        <input type="text" id="pseudo" name="pseudo">
+        <input type="text" id="username" name="username">
         <br />
         <label for="password">Mot de passe</label>
         <br />

--- a/templates/login.php
+++ b/templates/login.php
@@ -1,7 +1,7 @@
 <?php $this->title = "Connexion"; ?>
 
-<?= $this->session->show('error_login'); ?>
-<?= $this->session->show('need_login'); ?>
+<?= $this->session->show('error_login_message'); ?>
+<?= $this->session->show('need_login_message'); ?>
 
 <div>
     <form method="post" action="../public/index.php?route=login">

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -1,15 +1,15 @@
 <?php $this->title = 'Mon profil'; ?>
 
 <?php
-$loggedIn = isset($this->session) && $this->session->get('pseudo');
+$loggedIn = isset($this->session) && $this->session->get('user')->getPseudo();
 ?>
 
-<?= $this->session->show('update_email'); ?>
-<?= $this->session->show('update_password'); ?>
-<?= $this->session->show('not_admin'); ?>
+<?= $this->session->show('update_email_message'); ?>
+<?= $this->session->show('update_password_message'); ?>
+<?= $this->session->show('not_admin_message'); ?>
 
 <div>
-    <h2><?= $this->session->get('pseudo'); ?></h2>
+    <h2><?= $this->session->get('user')->getPseudo(); ?></h2>
     <p>Membre depuis le <?= $user->getCreatedAt(); ?></p>
     <p>Nombre de commentaires en ligne : <?= $user->getNumberOfComments(); ?></p>
 

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -9,26 +9,19 @@ $loggedIn = isset($this->session) && $this->session->get('user')->getPseudo();
 <?= $this->session->show('not_admin_message'); ?>
 
 <div>
-    <h2><?= $this->session->get('user')->getPseudo(); ?></h2>
+    <h2><?= $user->getPseudo(); ?></h2>
     <p>Membre depuis le <?= $user->getCreatedAt(); ?></p>
     <p>Nombre de commentaires en ligne : <?= $user->getNumberOfComments(); ?></p>
 
     <form method="post" action="../public/index.php?route=updateEmail">
         <label for="email">E-mail</label>
         <br />
-        <input type="email" id="email" name="email" value="<?= $loggedIn ? htmlspecialchars($user->getEmail()) : ''; ?>">
+        <input type="email" id="email" name="email" value="<?= htmlspecialchars($user->getEmail()); ?>">
         <br />
         <input type="submit" value="Mettre à jour mon e-mail" id="submitEmail" name="submitEmail">
     </form>
 
-    <form method="post" action="../public/index.php?route=updatePassword">
-        <label for="password">Mon mot de passe</label>
-        <br />
-        <input type="password" id="password" name="password" value="<?= $loggedIn ? htmlspecialchars($user->getPassword()) : ''; ?>">
-        <br />
-        <input type="submit" value="Mettre à jour mon mot de passe" id="submitPassword" name="submitPassword">
-    </form>
-    <!--<a href="../public/index.php?route=updatePassword">Modifier mon mot de passe</a>-->
+    <a href="../public/index.php?route=updatePassword">Modifier mon mot de passe</a>
     <a href="../public/index.php?route=deleteAccount">Supprimer mon compte</a>
 </div>
 <a href="../public/index.php">Retour à l'accueil</a>

--- a/templates/single.php
+++ b/templates/single.php
@@ -1,9 +1,9 @@
 <?php $this->title = $article->getTitle(); ?>
 
-<?= $this->session->show('add_comment'); ?>
-<?= $this->session->show('delete_comment'); ?>
-<?= $this->session->show('flag_comment'); ?>
-<?= $this->session->show('unflag_comment'); ?>
+<?= $this->session->show('add_comment_message'); ?>
+<?= $this->session->show('delete_comment_message'); ?>
+<?= $this->session->show('flag_comment_message'); ?>
+<?= $this->session->show('unflag_comment_message'); ?>
 
 <p>
     <a href="../public/index.php"><< Retour à l'accueil</a>
@@ -47,7 +47,7 @@ if(empty($article->getNextArticle()) == false)
 
 <br />
 <?php
-    if(($this->session->get('role') === 'admin'))
+    if($this->session->get('user')->getIsAdmin())
     {
         ?>
         <div class="actions">
@@ -111,7 +111,7 @@ if(empty($article->getNextArticle()) == false)
             </p>
         <?php
         }
-        if($this->session->get('pseudo') == $comment->getPseudo())
+        if($this->session->get('user')->getPseudo() == $comment->getPseudo())
         {
         ?>
         <p>

--- a/templates/update_password.php
+++ b/templates/update_password.php
@@ -1,14 +1,15 @@
 <?php $this->title = 'Modifier mon mot de passe'; ?>
 
 <div>
-    <p>Le mot de passe de <?= $this->session->get('user')->getPseudo(); ?> sera modifié</p>
+    <p>Le mot de passe de <span class="bold"><?= $this->session->get('user')->getPseudo(); ?></span> sera modifié</p>
     <form method="post" action="../public/index.php?route=updatePassword">
         <label for="password">Nouveau mot de passe</label>
         <br />
         <input type="password" id="password" name="password">
         <br />
+        <?= isset($errors['password']) ? $errors['password'] : ''; ?>
         <input type="submit" value="Mettre à jour" id="submit" name="submit">
     </form>
 </div>
 
-<a href="../public/index.php">Retour à l'accueil</a>
+<a href="../public/index.php?route=profile"><< Retour au profil</a>

--- a/templates/update_password.php
+++ b/templates/update_password.php
@@ -1,7 +1,7 @@
 <?php $this->title = 'Modifier mon mot de passe'; ?>
 
 <div>
-    <p>Le mot de passe de <?= $this->session->get('pseudo'); ?> sera modifié</p>
+    <p>Le mot de passe de <?= $this->session->get('user')->getPseudo(); ?> sera modifié</p>
     <form method="post" action="../public/index.php?route=updatePassword">
         <label for="password">Nouveau mot de passe</label>
         <br />


### PR DESCRIPTION
# CRITICAL CHANGES
New attribute 'isAdmin' on User object.
User object is stored into the session, so logged in user info can be accessed everywhere.
When logging in, password is checked after username.
User can log in either with pseudo or with email.
# CHANGES
User name is used to in welcome back message.
All session messages names are suffixed with '_message' so they can not be confused with templates names.
# CLOSES ISSUE
fixes #69 
fixes #52 
